### PR TITLE
List order fixes

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changes
+- Reverses blog, resources and testimonials listings, so that the highest number is the one at the top of the list
+
+### Fixes
+- Adds list semantics back on blog listings
+
 ----------
 
 

--- a/src/scss/base/typography/_mixins.scss
+++ b/src/scss/base/typography/_mixins.scss
@@ -94,6 +94,11 @@ $font--heading: 'FS Me Web', sans-serif;
   list-style: none;
   padding-left: 0;
 
+  li:before {
+    content: "\200B";
+    position: absolute;
+  }
+
   ul {
     list-style-type: disc;
 

--- a/src/site/blog.html
+++ b/src/site/blog.html
@@ -2,7 +2,7 @@
 title: Articles by Martin Underhill
 heading: Blog
 intro: |
-    If you’re interested in design and front-end dev, you’ll enjoy this blog. If you’re a website owner looking for tips, check out the [Resources](/resources). Categories is [listed elsewhere](/categories).
+    If you’re interested in design and front-end dev, you’ll enjoy this blog. If you’re a website owner looking for tips, check out the [Resources](/resources). Categories are [listed elsewhere](/categories).
 layout: base
 noCta: true
 ---

--- a/src/site/blog.html
+++ b/src/site/blog.html
@@ -7,7 +7,7 @@ layout: base
 noCta: true
 ---
 
-<ol class="hfeed index-list">
+<ol class="hfeed index-list" reversed>
     {% for post in collections.post | reverse %}
         {% include "post-in-list.html" %}
     {% endfor %}

--- a/src/site/resources.html
+++ b/src/site/resources.html
@@ -7,7 +7,7 @@ resources: true
 noCta: true
 ---
 
-<ul class="hfeed index-list">
+<ul class="hfeed index-list" reversed>
     {% for post in collections.resource | reverse %}
         {% include "post-in-list.html" %}
     {% endfor %}

--- a/src/site/testimonials.html
+++ b/src/site/testimonials.html
@@ -8,7 +8,7 @@ layout: base
 noCta: true
 ---
 
-<ul class="index-list">
+<ul class="index-list" reversed>
     {% for testimonial in collections.testimonial | sort(true, false, 'date') %}
         <li>
             <h2><a href="{{ testimonial.url | replace(".html", "") }}">{{ testimonial.data.title }}</a></h2>


### PR DESCRIPTION
Fixes accessiblity for blog, resource and testimonial listings.

1. Uses the `reversed` attribute on the `<ol>` so that it’s clear that the first in the list isn’t the first that was added
2. Uses [Scott O’Hara’s method](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html) of fixing lists with `list-style: none`

This will close #97 